### PR TITLE
[Feature] Admin Shell scaffold (admin route + layout)

### DIFF
--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -1,9 +1,5 @@
-import React from 'react'
+import { AdminShell } from '@features/admin/layout/AdminShell'
 
-export const metadata = { title: '하루빛 관리자', description: '관리자 패널 레이아웃' }
-
-type Props = { children: React.ReactNode }
-
-export default function AdminLayout({ children }: Props) {
-  return <div>{children}</div>
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return <AdminShell>{children}</AdminShell>
 }

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export const metadata = { title: '하루빛 관리자', description: '관리자 패널 레이아웃' }
+
+type Props = { children: React.ReactNode }
+
+export default function AdminLayout({ children }: Props) {
+  return <div>{children}</div>
+}

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminPage() {
+  return <div>Admin Dashboard</div>
+}

--- a/src/features/admin/layout/AdminHeader.tsx
+++ b/src/features/admin/layout/AdminHeader.tsx
@@ -1,0 +1,3 @@
+export function AdminHeader() {
+  return <header className="flex h-14 items-center border-b px-6">관리자 페이지</header>
+}

--- a/src/features/admin/layout/AdminShell.tsx
+++ b/src/features/admin/layout/AdminShell.tsx
@@ -1,0 +1,9 @@
+export function AdminShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen">
+      <div className="flex flex-1 flex-col">
+        <main className="flex-1 p-6">{children}</main>
+      </div>
+    </div>
+  )
+}

--- a/src/features/admin/layout/AdminShell.tsx
+++ b/src/features/admin/layout/AdminShell.tsx
@@ -1,7 +1,12 @@
+import { AdminHeader } from './AdminHeader'
+import { AdminSidebar } from './AdminSidebar'
+
 export function AdminShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex min-h-screen">
+      <AdminSidebar />
       <div className="flex flex-1 flex-col">
+        <AdminHeader />
         <main className="flex-1 p-6">{children}</main>
       </div>
     </div>

--- a/src/features/admin/layout/AdminSidebar.tsx
+++ b/src/features/admin/layout/AdminSidebar.tsx
@@ -1,0 +1,7 @@
+export function AdminSidebar() {
+  return (
+    <aside className="w-64 border-r p-4">
+      <h2 className="font-bold">Admin</h2>
+    </aside>
+  )
+}

--- a/src/features/admin/navigation/admin-menu.ts
+++ b/src/features/admin/navigation/admin-menu.ts
@@ -1,0 +1,57 @@
+import type { LucideIcon } from "lucide-react"
+import {
+  CalendarRange,
+  LayoutDashboard,
+  NotebookPen,
+} from "lucide-react"
+
+export type AdminRole =
+  | "mainAdmin"
+  | "subAdmin"
+  | "communityAdmin"
+  | "groupAdmin"
+
+export type AdminNavItem = {
+  key: string
+  label: string
+  href?: string
+  icon?: LucideIcon
+  roles?: AdminRole[]        // 없으면 모든 관리자 역할에 노출
+  children?: AdminNavItem[]
+  disabled?: boolean
+}
+
+export const ADMIN_NAV: AdminNavItem[] = [
+  {
+    key: "dashboard",
+    label: "관리자 홈",
+    href: "/admin",
+    icon: LayoutDashboard,
+    roles: ["mainAdmin", "subAdmin"], // MVP 기준: 우선 메인/서브만
+  },
+  {
+    key: "seasons",
+    label: "시즌 관리",
+    href: "/admin/seasons",
+    icon: CalendarRange,
+    roles: ["mainAdmin", "subAdmin"],
+  },
+  {
+    key: "plans",
+    label: "성경 일정 관리",
+    icon: NotebookPen,
+    roles: ["mainAdmin", "subAdmin"],
+    children: [
+      {
+        key: "plans-seasons",
+        label: "시즌 기준 관리",
+        href: "/admin/plans/seasons",
+      },
+      {
+        key: "plans-dates",
+        label: "날짜 기준 관리",
+        href: "/admin/plans/dates",
+      },
+    ],
+  },
+]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,6 +43,9 @@
       ],
       "@libs/*": [
         "./src/libs/*"
+      ],
+      "@features/*": [
+        "./src/features/*"
       ]
     }
   },


### PR DESCRIPTION
## 📌개요
관리자 페이지 구현을 시작하기 위해, App Router에서 관리자 영역을 분리하고((admin) route group), 대시보드 형태의 공통 레이아웃(Admin Shell)을 먼저 스캐폴딩한다. 초기 단계에서는 권한/데이터 연동 없이 **레이아웃(사이드바/헤더/컨텐츠 영역) 구조**만 구축하며, 이후 shadcn/ui dashboard-01 블록 스타일로 UI를 확장한다.

## ❗️관련 이슈 링크
Close #83 
[[Feature] Admin Shell 스캐폴딩 구축 (App Router + shadcn dashboard 기반)](https://github.com/AMeaningfulStar/dongan-bibile/issues/83)

## 📍 PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## 🔎 작업 내용
1. **라우팅 그룹/페이지 뼈대 생성** 을 했습니다.
- `src/app/(admin)/admin/layout.tsx` 생성 (Admin Shell 연결)
- `src/app/(admin)/admin/page.tsx` 생성 (Admin Dashboard placeholder)
- `/admin` 라우팅 정상 동작 확인

2. **관리자 레이아웃 컴포넌트 스캐폴딩** 했습니다.
- `src/features/admin/layout/AdminShell.tsx` 생성
- `src/features/admin/layout/AdminSidebar.tsx` 생성 (텍스트/placeholder)
- `src/features/admin/layout/AdminHeader.tsx` 생성 (텍스트/placeholder)

3. **관리자 메뉴 구조 파일 추가(초안)** 했습니다.
- `src/features/admin/navigation/admin-menu.ts` 생성

## 🔧 앞으로의 과제
- shadcn/ui dashboard-01 완전 이식

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
