### PR TITLE
[Feature] Admin Sidebar 메뉴 UI 구현 (MVP 네비게이션)

### DIFF
--- a/src/app/(admin)/admin/plans/dates/page.tsx
+++ b/src/app/(admin)/admin/plans/dates/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Coming soon: /admin/plans/dates</div>
+}

--- a/src/app/(admin)/admin/plans/page.tsx
+++ b/src/app/(admin)/admin/plans/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Coming soon: /admin/plans</div>
+}

--- a/src/app/(admin)/admin/plans/seasons/page.tsx
+++ b/src/app/(admin)/admin/plans/seasons/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Coming soon: /admin/plans/seasons</div>
+}

--- a/src/app/(admin)/admin/seasons/page.tsx
+++ b/src/app/(admin)/admin/seasons/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Coming soon: /admin/seasons</div>
+}

--- a/src/features/admin/layout/AdminSidebar.tsx
+++ b/src/features/admin/layout/AdminSidebar.tsx
@@ -1,9 +1,9 @@
 // src/features/admin/layout/AdminSidebar.tsx
-"use client"
+'use client'
 
-import Link from "next/link"
-import { usePathname } from "next/navigation"
-import { ADMIN_NAV } from "../navigation/admin-menu"
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { ADMIN_NAV } from '../navigation/admin-menu'
 
 export function AdminSidebar() {
   const pathname = usePathname()
@@ -15,8 +15,9 @@ export function AdminSidebar() {
       <nav className="space-y-2">
         {ADMIN_NAV.map((item) => {
           const isActive =
-            pathname === item.href ||
-            pathname.startsWith(item.href + "/")
+            item.href === '/admin'
+              ? pathname === '/admin'
+              : pathname === item.href || pathname.startsWith(item.href + '/')
 
           return (
             <div key={item.key}>
@@ -24,9 +25,7 @@ export function AdminSidebar() {
               <Link
                 href={item.href}
                 className={`block rounded px-3 py-2 text-sm ${
-                  isActive
-                    ? "bg-muted font-medium"
-                    : "text-muted-foreground hover:bg-muted"
+                  isActive ? 'bg-muted font-medium' : 'text-muted-foreground hover:bg-muted'
                 }`}
               >
                 {item.label}
@@ -36,18 +35,14 @@ export function AdminSidebar() {
               {item.children && (
                 <div className="ml-4 mt-1 space-y-1">
                   {item.children.map((child) => {
-                    const isChildActive =
-                      pathname === child.href ||
-                      pathname.startsWith(child.href + "/")
+                    const isChildActive = pathname === child.href || pathname.startsWith(child.href + '/')
 
                     return (
                       <Link
                         key={child.key}
                         href={child.href}
                         className={`block rounded px-3 py-1.5 text-sm ${
-                          isChildActive
-                            ? "bg-muted font-medium"
-                            : "text-muted-foreground hover:bg-muted"
+                          isChildActive ? 'bg-muted font-medium' : 'text-muted-foreground hover:bg-muted'
                         }`}
                       >
                         {child.label}

--- a/src/features/admin/layout/AdminSidebar.tsx
+++ b/src/features/admin/layout/AdminSidebar.tsx
@@ -1,7 +1,65 @@
+// src/features/admin/layout/AdminSidebar.tsx
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { ADMIN_NAV } from "../navigation/admin-menu"
+
 export function AdminSidebar() {
+  const pathname = usePathname()
+
   return (
     <aside className="w-64 border-r p-4">
-      <h2 className="font-bold">Admin</h2>
+      <h2 className="mb-4 font-bold">Admin</h2>
+
+      <nav className="space-y-2">
+        {ADMIN_NAV.map((item) => {
+          const isActive =
+            pathname === item.href ||
+            pathname.startsWith(item.href + "/")
+
+          return (
+            <div key={item.key}>
+              {/* 상위 메뉴 */}
+              <Link
+                href={item.href}
+                className={`block rounded px-3 py-2 text-sm ${
+                  isActive
+                    ? "bg-muted font-medium"
+                    : "text-muted-foreground hover:bg-muted"
+                }`}
+              >
+                {item.label}
+              </Link>
+
+              {/* 하위 메뉴 */}
+              {item.children && (
+                <div className="ml-4 mt-1 space-y-1">
+                  {item.children.map((child) => {
+                    const isChildActive =
+                      pathname === child.href ||
+                      pathname.startsWith(child.href + "/")
+
+                    return (
+                      <Link
+                        key={child.key}
+                        href={child.href}
+                        className={`block rounded px-3 py-1.5 text-sm ${
+                          isChildActive
+                            ? "bg-muted font-medium"
+                            : "text-muted-foreground hover:bg-muted"
+                        }`}
+                      >
+                        {child.label}
+                      </Link>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </nav>
     </aside>
   )
 }

--- a/src/features/admin/navigation/admin-menu.ts
+++ b/src/features/admin/navigation/admin-menu.ts
@@ -5,20 +5,19 @@ import {
   NotebookPen,
 } from "lucide-react"
 
-export type AdminRole =
-  | "mainAdmin"
-  | "subAdmin"
-  | "communityAdmin"
-  | "groupAdmin"
+// export type AdminRole =
+//   | "mainAdmin"
+//   | "subAdmin"
+//   | "communityAdmin"
+//   | "groupAdmin"
 
 export type AdminNavItem = {
   key: string
   label: string
-  href?: string
+  href: string
   icon?: LucideIcon
-  roles?: AdminRole[]        // 없으면 모든 관리자 역할에 노출
+  // roles?: AdminRole[]        // 없으면 모든 관리자 역할에 노출
   children?: AdminNavItem[]
-  disabled?: boolean
 }
 
 export const ADMIN_NAV: AdminNavItem[] = [
@@ -27,20 +26,18 @@ export const ADMIN_NAV: AdminNavItem[] = [
     label: "관리자 홈",
     href: "/admin",
     icon: LayoutDashboard,
-    roles: ["mainAdmin", "subAdmin"], // MVP 기준: 우선 메인/서브만
   },
   {
     key: "seasons",
     label: "시즌 관리",
     href: "/admin/seasons",
-    icon: CalendarRange,
-    roles: ["mainAdmin", "subAdmin"],
+    icon: CalendarRange
   },
   {
     key: "plans",
     label: "성경 일정 관리",
+    href: "/admin/plans",
     icon: NotebookPen,
-    roles: ["mainAdmin", "subAdmin"],
     children: [
       {
         key: "plans-seasons",


### PR DESCRIPTION
## 📌개요
관리자 페이지의 다음 기능 개발(시즌/플랜 CRUD)을 진행하기에 앞서,
admin-menu.ts를 source of truth로 두고 **Admin Sidebar 메뉴를 데이터 기반으로 렌더링**했습니다.

이번 PR은 디자인(shadcn dashboard-01 이식)이나 권한/데이터 연동 없이,
**메뉴 렌더링 · 라우팅 이동 · active 상태 표시**까지의 MVP 네비게이션을 완성하는 데 집중합니다.

## ❗️관련 이슈 링크
Close #85 
[[Feature] Admin Sidebar 메뉴 UI 구현 (MVP 네비게이션)](https://github.com/AMeaningfulStar/dongan-bibile/issues/85)

## 📍 PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## 🔎 작업 내용
#### 1) 관리자 메뉴 데이터(MVP) 확정
- `src/features/admin/navigation/admin-menu.ts`
  - 관리자 홈(/admin)
  - 시즌 관리(/admin/seasons)
  - 성경 일정 관리(/admin/plans) + 하위 메뉴
  - 시즌 기준(/admin/plans/seasons)
  - 날짜 기준(/admin/plans/dates)

#### 2) AdminSidebar 렌더링 및 active 상태 처리
- `src/features/admin/layout/AdminSidebar.tsx`
  - ADMIN_NAV 기반으로 메뉴 렌더링
  - usePathname()로 active 상태 표시
  - **루트 경로(/admin)는 예외 처리 + 나머지는 startsWith 기반으로 하위 라우트까지 active 유지**
    - /admin/seasons/123 같은 확장 라우트에서도 “시즌 관리” 메뉴 active 유지 가능

#### 3) 메뉴 검증용 placeholder 라우트 추가
- `src/app/(admin)/admin/seasons/page.tsx`
- `src/app/(admin)/admin/plans/page.tsx`
- `src/app/(admin)/admin/plans/seasons/page.tsx`
- `src/app/(admin)/admin/plans/dates/page.tsx`

> 각 페이지는 Coming soon 수준으로 구성하여 메뉴 이동/active 검증을 우선 완료했습니다.

## 🔧 앞으로의 과제
- shadcn/ui dashboard-01 블록 스타일 단계적 이식(사이드바/헤더/UI 톤)
- 시즌 관리 CRUD 구현
- 일정(플랜) 관리 CRUD 구현
- 권한(Role/Scope) 기반 메뉴 노출 + 접근 제어(middleware) 적용

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
